### PR TITLE
SEO: index.html head, JSON-LD, crawlable fallback content

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,23 +6,97 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <!-- Primary Meta Tags -->
-    <title>App Store & Play Store Localizer - Translate Your Apps Instantly</title>
-    <meta name="title" content="App Store & Play Store Localizer - Translate Your Apps Instantly" />
+    <title>App Store & Play Store Localizer — Free AI Translation</title>
+    <meta name="title" content="App Store & Play Store Localizer — Free AI Translation" />
     <meta name="description" content="Free, open-source tool to translate your App Store and Google Play listings using AI. Support for 40+ languages." />
-    <meta name="keywords" content="xcstrings, localization, iOS, macOS, Android, Google Play, Swift, translation, i18n, internationalization, GPT, AI translation, App Store Connect, ASO" />
     <meta name="author" content="Fayhe" />
+
+    <!-- Canonical -->
+    <link rel="canonical" href="https://storelocalizer.com/" />
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="App Store & Play Store Localizer - Translate Your Apps Instantly" />
+    <meta property="og:url" content="https://storelocalizer.com/" />
+    <meta property="og:site_name" content="StoreLocalizer" />
+    <meta property="og:title" content="App Store & Play Store Localizer — Free AI Translation" />
     <meta property="og:description" content="Free, open-source tool to translate your App Store and Google Play listings using AI. Support for 40+ languages." />
-    <meta property="og:image" content="https://images.unsplash.com/photo-1451187580459-43490279c0fa?w=1200&h=630&fit=crop" />
+    <meta property="og:image" content="https://storelocalizer.com/og.png" />
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image" />
-    <meta property="twitter:title" content="App Store & Play Store Localizer - Translate Your Apps Instantly" />
+    <meta property="twitter:title" content="App Store & Play Store Localizer — Free AI Translation" />
     <meta property="twitter:description" content="Free, open-source tool to translate your App Store and Google Play listings using AI." />
-    <meta property="twitter:image" content="https://images.unsplash.com/photo-1451187580459-43490279c0fa?w=1200&h=630&fit=crop" />
+    <meta property="twitter:image" content="https://storelocalizer.com/og.png" />
+
+    <!-- Structured Data -->
+    <script type="application/ld+json">
+      [
+        {
+          "@context": "https://schema.org",
+          "@type": "WebSite",
+          "name": "StoreLocalizer",
+          "url": "https://storelocalizer.com/"
+        },
+        {
+          "@context": "https://schema.org",
+          "@type": "SoftwareApplication",
+          "name": "StoreLocalizer",
+          "applicationCategory": "DeveloperApplication",
+          "operatingSystem": "Web",
+          "offers": {
+            "@type": "Offer",
+            "price": "0",
+            "priceCurrency": "USD"
+          },
+          "description": "Translate your App Store and Google Play listings into 40+ languages with AI. Free and open-source."
+        },
+        {
+          "@context": "https://schema.org",
+          "@type": "Organization",
+          "name": "StoreLocalizer",
+          "url": "https://storelocalizer.com/",
+          "sameAs": ["https://github.com/fayharinn/StoreLocalizer"]
+        },
+        {
+          "@context": "https://schema.org",
+          "@type": "FAQPage",
+          "mainEntity": [
+            {
+              "@type": "Question",
+              "name": "Is StoreLocalizer free?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "Yes. StoreLocalizer is completely free and open-source. You only need your own AI provider API key to run translations."
+              }
+            },
+            {
+              "@type": "Question",
+              "name": "How many languages are supported?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "StoreLocalizer can translate your App Store and Google Play listings into more than 40 languages using AI."
+              }
+            },
+            {
+              "@type": "Question",
+              "name": "Does it connect to App Store Connect and Google Play?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "Yes. StoreLocalizer integrates directly with App Store Connect and the Google Play Console so you can fetch, translate, and push localized metadata."
+              }
+            },
+            {
+              "@type": "Question",
+              "name": "What is an .xcstrings file?",
+              "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "An .xcstrings file is Apple's String Catalog format used in Xcode to manage app localizations. StoreLocalizer parses, translates, and exports these files locally in your browser."
+              }
+            }
+          ]
+        }
+      ]
+    </script>
 
     <!-- Theme Color - Dynamic based on theme -->
     <meta name="theme-color" content="#7c3aed" media="(prefers-color-scheme: dark)" />
@@ -40,7 +114,34 @@
     </script>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <div style="max-width:880px;margin:0 auto;padding:40px 20px;color:#e5e5e5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#0a0a0a">
+        <h1 style="font-size:2rem;line-height:1.2;margin:0 0 16px">App Store & Play Store Localizer</h1>
+        <p style="font-size:1.05rem;line-height:1.6;color:#a3a3a3;margin:0 0 28px">
+          StoreLocalizer is a free, open-source tool that translates your App Store and Google Play
+          listings into 40+ languages with AI. Connect to App Store Connect and the Google Play Console
+          to fetch, translate, and publish localized metadata, screenshots, and pricing.
+        </p>
+        <h2 style="font-size:1.3rem;margin:0 0 12px">Features</h2>
+        <ul style="line-height:1.8;padding-left:20px;margin:0 0 28px">
+          <li><a href="/app-store-localization.html" style="color:#a78bfa">App Store localization</a> — translate App Store Connect metadata and ASO fields.</li>
+          <li><a href="/google-play-localization.html" style="color:#a78bfa">Google Play localization</a> — localize Play Console listings in bulk.</li>
+          <li><a href="/xcstrings-translator.html" style="color:#a78bfa">.xcstrings translator</a> — translate Xcode String Catalogs locally in your browser.</li>
+          <li><a href="/app-store-screenshots.html" style="color:#a78bfa">App Store screenshots</a> — generate device-framed, localized screenshots.</li>
+          <li><a href="/subscription-pricing.html" style="color:#a78bfa">Subscription pricing</a> — GDP-adjusted in-app purchase price recommendations.</li>
+        </ul>
+        <h2 style="font-size:1.3rem;margin:0 0 12px">FAQ</h2>
+        <h3 style="font-size:1.05rem;margin:0 0 4px">Is StoreLocalizer free?</h3>
+        <p style="line-height:1.6;color:#a3a3a3;margin:0 0 16px">Yes. It is completely free and open-source — you only bring your own AI provider API key.</p>
+        <h3 style="font-size:1.05rem;margin:0 0 4px">How many languages are supported?</h3>
+        <p style="line-height:1.6;color:#a3a3a3;margin:0 0 16px">More than 40 languages for both App Store and Google Play listings.</p>
+        <h3 style="font-size:1.05rem;margin:0 0 4px">Does it connect to App Store Connect and Google Play?</h3>
+        <p style="line-height:1.6;color:#a3a3a3;margin:0 0 28px">Yes. It integrates directly with both so you can fetch, translate, and push localized metadata.</p>
+        <footer style="border-top:1px solid #262626;padding-top:20px;color:#737373;font-size:0.9rem">
+          Open-source on <a href="https://github.com/fayharinn/StoreLocalizer" style="color:#a78bfa">GitHub</a>.
+        </footer>
+      </div>
+    </div>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
Overhauls `index.html` `<head>` and the `#root` fallback for SEO.

### Head changes
- Shortened `<title>` and `<meta name="title">` to `App Store & Play Store Localizer — Free AI Translation` (< 60 chars)
- Removed obsolete `<meta name="keywords">` (ignored by Google)
- Added `<link rel="canonical" href="https://storelocalizer.com/">`
- Added `og:url` and `og:site_name`
- Pointed both `og:image` and `twitter:image` at `https://storelocalizer.com/og.png` (image asset created by a separate worker)
- Added one `application/ld+json` block: `WebSite`, `SoftwareApplication` (free Offer), `Organization`, and a 4-question `FAQPage`

### Body changes
- Replaced the empty `<div id="root">` with crawlable no-JS fallback content: `<h1>`, intro paragraph, a feature list linking to the 5 landing pages (`/app-store-localization.html`, `/google-play-localization.html`, `/xcstrings-translator.html`, `/app-store-screenshots.html`, `/subscription-pricing.html`), a 3-question FAQ, and a GitHub footer. Minimal dark-theme inline styles so the pre-React flash looks acceptable. React replaces these children on mount.

Did not touch the inline theme script, favicon, viewport, theme-color metas, or the module script tag.

## Verification
- `bun run build` succeeds; built `dist/index.html` contains canonical, ld+json, og:url, `storelocalizer.com/og.png`, and the `<h1>`; `name="keywords"` is gone
- JSON-LD parses via `JSON.parse` (source and dist)
- `bun run lint` shows only pre-existing errors in untouched `.js` files; HTML is not linted and no new errors were introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)