### PR TITLE
SEO: add sitemap.xml

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://storelocalizer.com/</loc>
+    <lastmod>2026-06-03</lastmod>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://storelocalizer.com/app-store-localization.html</loc>
+    <lastmod>2026-06-03</lastmod>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://storelocalizer.com/google-play-localization.html</loc>
+    <lastmod>2026-06-03</lastmod>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://storelocalizer.com/xcstrings-translator.html</loc>
+    <lastmod>2026-06-03</lastmod>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://storelocalizer.com/app-store-screenshots.html</loc>
+    <lastmod>2026-06-03</lastmod>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://storelocalizer.com/subscription-pricing.html</loc>
+    <lastmod>2026-06-03</lastmod>
+    <priority>0.8</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
Adds `public/sitemap.xml` listing the home plus the 5 SEO landing pages (lastmod 2026-06-03). Cloudflare Pages serves it verbatim from the build output, fixing the current soft-200 (sitemap.xml previously returned the SPA HTML).

Part of the SEO batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)