### PR TITLE
SEO: add robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://storelocalizer.com/sitemap.xml


### PR DESCRIPTION
## What

Adds `public/robots.txt`. Cloudflare Pages copies `public/` → `dist/` during `bun run build`, so this serves verbatim at the site root.

## Why

Currently there is no robots.txt — requests to `/robots.txt` return the SPA `index.html` with a 200 (soft-200 bug). Crawlers get HTML instead of crawl directives.

## Content

```
User-agent: *
Allow: /

Sitemap: https://storelocalizer.com/sitemap.xml
```

Allows all crawlers and references the sitemap (created by a separate change).

## Verification

- `bun run build` succeeds.
- `dist/robots.txt` is present after build with the correct content.
- `bun run preview` + `curl http://localhost:4173/robots.txt` returns the robots content (not HTML).
- `bun run lint` failures are all pre-existing on the base branch (identical 346-problem count with this change stashed); this static file adds none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)