### PR TITLE
Fixed an issue where batch translation for `screenshots` would not work, displaying the message "Add more languages to translate to" even when languages were already configured in `manage translations`.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2632,9 +2632,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2650,9 +2647,6 @@
       "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2670,9 +2664,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2688,9 +2679,6 @@
       "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2708,9 +2696,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2726,9 +2711,6 @@
       "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2948,9 +2930,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2966,9 +2945,6 @@
       "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2986,9 +2962,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3004,9 +2977,6 @@
       "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3181,9 +3151,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -3201,9 +3168,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -3221,9 +3185,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -3241,9 +3202,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -3261,9 +3219,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [

--- a/src/components/ScreenshotMaker/components/CanvasArea.jsx
+++ b/src/components/ScreenshotMaker/components/CanvasArea.jsx
@@ -313,6 +313,7 @@ export default function CanvasArea({ state, dispatch, threeRenderer, getScreensh
     dims,
     previewScale,
     updateSidePreviews,
+    getScreenshotImage,
   ]);
 
   // -----------------------------------------------------------------------

--- a/src/components/ScreenshotMaker/components/CanvasArea.jsx
+++ b/src/components/ScreenshotMaker/components/CanvasArea.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import React, { useEffect, useRef, useCallback, useMemo } from 'react';
 import { deviceDimensions } from '../constants';
 import { SELECT_SCREENSHOT, SET_SCREENSHOT_SETTING } from '../hooks/useAppState';
 import {
@@ -134,83 +134,31 @@ export default function CanvasArea({ state, dispatch, threeRenderer, getScreensh
   }, [use3D, threeRenderer, state.screenshots, state.selectedIndex, state.currentLanguage, state.defaults, getScreenshotImage]);
 
   // -----------------------------------------------------------------------
-  // updateCanvas – draws the main preview canvas
+  // renderSideCanvas – render a single screenshot to a side preview canvas
   // -----------------------------------------------------------------------
 
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
+  const renderSideCanvas = useCallback(
+    (index, targetCanvas) => {
+      if (!targetCanvas) return;
+      const screenshot = state.screenshots[index];
+      if (!screenshot) return;
 
-    const ctx = canvas.getContext('2d');
+      renderScreenshotToCanvas(
+        targetCanvas,
+        screenshot,
+        dims.width,
+        dims.height,
+        state.currentLanguage,
+        state.projectLanguages,
+        threeRenderer
+      );
 
-    // Set internal resolution
-    canvas.width = dims.width;
-    canvas.height = dims.height;
-
-    // Scale for preview display
-    canvas.style.width = dims.width * previewScale + 'px';
-    canvas.style.height = dims.height * previewScale + 'px';
-
-    // If no screenshots, clear canvas and let the "no-screenshot" overlay show
-    if (state.screenshots.length === 0) {
-      ctx.clearRect(0, 0, dims.width, dims.height);
-      return;
-    }
-
-    // Draw background
-    const bg = getBackground(state);
-    drawBackgroundToContext(ctx, dims, bg);
-
-    // Draw noise overlay if enabled
-    if (bg.noise) {
-      drawNoiseToContext(ctx, dims, bg.noiseIntensity);
-    }
-
-    // Draw screenshot (2D) or 3D phone model
-    if (state.screenshots.length > 0) {
-      const ss = getScreenshotSettings(state);
-      const is3D = ss.use3D || false;
-
-      if (is3D && threeRenderer && typeof threeRenderer.renderToCanvas === 'function' && threeRenderer.isLoaded && threeRenderer.isLoaded()) {
-        // 3D mode – render to canvas with current screenshot settings
-        threeRenderer.renderToCanvas(canvas, dims.width, dims.height, ss);
-      } else if (!is3D) {
-        // 2D mode
-        const screenshot = state.screenshots[state.selectedIndex];
-        if (screenshot) {
-          const img = getScreenshotImage(screenshot);
-          if (img) {
-            drawScreenshotToContext(ctx, dims, img, ss);
-          }
-        }
-      }
-    }
-
-    // Draw text
-    const txt = getTextSettings(state);
-    drawTextToContext(ctx, dims, txt);
-
-    // Draw overlay/logo
-    const screenshot = state.screenshots[state.selectedIndex];
-    const overlay = screenshot?.overlay;
-    if (overlay) {
-      drawOverlayToContext(ctx, dims, overlay);
-    }
-
-    // Update side previews after main canvas is drawn
-    updateSidePreviews();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    state.screenshots,
-    state.selectedIndex,
-    state.outputDevice,
-    state.customWidth,
-    state.customHeight,
-    state.currentLanguage,
-    state.defaults,
-    dims,
-    previewScale,
-  ]);
+      // Apply preview scale to display size
+      targetCanvas.style.width = dims.width * previewScale + 'px';
+      targetCanvas.style.height = dims.height * previewScale + 'px';
+    },
+    [state, dims, previewScale, threeRenderer]
+  );
 
   // -----------------------------------------------------------------------
   // updateSidePreviews – renders adjacent screenshots to side canvases
@@ -279,35 +227,93 @@ export default function CanvasArea({ state, dispatch, threeRenderer, getScreensh
         farRightWrapper.classList.add('hidden');
       }
     },
-    [state, dims, previewScale]
+    [state, dims, previewScale, renderSideCanvas]
   );
 
   // -----------------------------------------------------------------------
-  // renderSideCanvas – render a single screenshot to a side preview canvas
+  // updateCanvas – draws the main preview canvas
   // -----------------------------------------------------------------------
 
-  const renderSideCanvas = useCallback(
-    (index, targetCanvas) => {
-      if (!targetCanvas) return;
-      const screenshot = state.screenshots[index];
-      if (!screenshot) return;
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
 
-      renderScreenshotToCanvas(
-        targetCanvas,
-        screenshot,
-        dims.width,
-        dims.height,
-        state.currentLanguage,
-        state.projectLanguages,
-        threeRenderer
-      );
+    const ctx = canvas.getContext('2d');
 
-      // Apply preview scale to display size
-      targetCanvas.style.width = dims.width * previewScale + 'px';
-      targetCanvas.style.height = dims.height * previewScale + 'px';
-    },
-    [state, dims, previewScale, threeRenderer]
-  );
+    // Set internal resolution
+    canvas.width = dims.width;
+    canvas.height = dims.height;
+
+    // Scale for preview display
+    canvas.style.width = dims.width * previewScale + 'px';
+    canvas.style.height = dims.height * previewScale + 'px';
+
+    // If no screenshots, clear canvas and let the "no-screenshot" overlay show
+    if (state.screenshots.length === 0) {
+      ctx.clearRect(0, 0, dims.width, dims.height);
+      return;
+    }
+
+    // Draw background
+    const bg = getBackground(state);
+    drawBackgroundToContext(ctx, dims, bg);
+
+    // Draw noise overlay if enabled
+    if (bg.noise) {
+      drawNoiseToContext(ctx, dims, bg.noiseIntensity);
+    }
+
+    // Draw screenshot (2D) or 3D phone model
+    if (state.screenshots.length > 0) {
+      const ss = getScreenshotSettings(state);
+      const is3D = ss.use3D || false;
+
+      if (is3D && threeRenderer && typeof threeRenderer.renderToCanvas === 'function' && threeRenderer.isLoaded && threeRenderer.isLoaded()) {
+        // 3D mode – render to canvas with current screenshot settings
+        threeRenderer.renderToCanvas(canvas, dims.width, dims.height, ss);
+      } else if (!is3D) {
+        // 2D mode
+        const screenshot = state.screenshots[state.selectedIndex];
+        if (screenshot) {
+          const img = getScreenshotImage(screenshot);
+          if (img) {
+            drawScreenshotToContext(ctx, dims, img, ss);
+          }
+        }
+      }
+    }
+
+    // Draw text
+    const txt = getTextSettings(state);
+    const txtWithLang = {
+      ...txt,
+      currentHeadlineLang: state.currentLanguage,
+      currentSubheadlineLang: state.currentLanguage,
+    };
+    drawTextToContext(ctx, dims, txtWithLang);
+
+    // Draw overlay/logo
+    const screenshot = state.screenshots[state.selectedIndex];
+    const overlay = screenshot?.overlay;
+    if (overlay) {
+      drawOverlayToContext(ctx, dims, overlay);
+    }
+
+    // Update side previews after main canvas is drawn
+    updateSidePreviews();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    state.screenshots,
+    state.selectedIndex,
+    state.outputDevice,
+    state.customWidth,
+    state.customHeight,
+    state.currentLanguage,
+    state.defaults,
+    dims,
+    previewScale,
+    updateSidePreviews,
+  ]);
 
   // -----------------------------------------------------------------------
   // slideToScreenshot – animated transition when clicking side previews

--- a/src/components/ScreenshotMaker/components/LeftSidebar.jsx
+++ b/src/components/ScreenshotMaker/components/LeftSidebar.jsx
@@ -36,10 +36,6 @@ import {
   getAvailableLanguagesForScreenshot,
   isScreenshotComplete,
 } from '../utils/languageUtils';
-import {
-  saveProjectsMeta,
-  deleteProjectState,
-} from '../utils/persistence';
 
 // =============================================================================
 // Device options for the output size dropdown
@@ -301,13 +297,12 @@ export default function LeftSidebar({
     reader.onload = (ev) => {
       const img = new Image();
       img.onload = () => {
-        const detectedLang = detectLanguageFromFilename(file.name);
-        // Dispatch a localized image set for the replacement
+        // Dispatch a localized image set for the replacement under the current active language
         dispatch({
           type: 'SET_LOCALIZED_IMAGE',
           payload: {
             screenshotIndex: targetIdx,
-            lang: detectedLang,
+            lang: currentLanguage,
             image: img,
             src: ev.target.result,
             name: file.name,
@@ -318,7 +313,7 @@ export default function LeftSidebar({
     };
     reader.readAsDataURL(file);
     e.target.value = '';
-  }, [dispatch]);
+  }, [dispatch, currentLanguage]);
 
   // ---------------------------------------------------------------------------
   // Drag and drop reordering
@@ -506,8 +501,9 @@ export default function LeftSidebar({
     const isDragOver = index === dragOverIndex && dragIndex !== index;
     const isTransferTarget = transferTarget === index;
 
-    // Get the first available image for thumbnail
-    const thumbSrc = screenshot.image?.src
+    // Get image for thumbnail: prefer current language, fall back to first available
+    const thumbSrc = (screenshot.localizedImages?.[currentLanguage]?.image?.src)
+      || screenshot.image?.src
       || (screenshot.localizedImages && Object.values(screenshot.localizedImages).find(l => l?.image)?.image?.src)
       || null;
 
@@ -612,12 +608,9 @@ export default function LeftSidebar({
   // ---------------------------------------------------------------------------
   // Render
   // ---------------------------------------------------------------------------
-  const Wrapper = mobile ? React.Fragment : ({ children }) => <div className="sidebar">{children}</div>;
-  const ContentWrapper = mobile ? React.Fragment : ({ children }) => <div className="sidebar-content">{children}</div>;
-
   return (
-    <Wrapper>
-      <ContentWrapper>
+    <div className={mobile ? '' : 'sidebar'}>
+      <div className={mobile ? '' : 'sidebar-content'}>
         {/* ---- Header with undo/redo, language picker and AI indicator ---- */}
         <div className="sidebar-header">
           <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
@@ -864,7 +857,7 @@ export default function LeftSidebar({
             Translate All Languages
           </button>
         </div>
-      </ContentWrapper>
+      </div>
 
       {/* ---- Sidebar footer with export controls ---- */}
       <div className={mobile ? '' : 'sidebar-footer'}>
@@ -1008,6 +1001,6 @@ export default function LeftSidebar({
         </div>
       )}
 
-    </Wrapper>
+    </div>
   );
 }

--- a/src/components/ScreenshotMaker/components/Modals.jsx
+++ b/src/components/ScreenshotMaker/components/Modals.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import React, { useState, useRef, useCallback, useMemo } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -30,11 +30,14 @@ export function TranslateModal({ visible, onClose, target, state, dispatch, aiCo
   const currentScreenshot = state.screenshots[state.selectedIndex];
   const text = currentScreenshot?.text || state.defaults?.text || {};
 
-  const languages = isHeadline ? (text.headlineLanguages || ['en']) : (text.subheadlineLanguages || ['en']);
-  const texts = isHeadline ? (text.headlines || {}) : (text.subheadlines || {});
+  const languages = useMemo(() => state.projectLanguages || ['en'], [state.projectLanguages]);
+  const texts = useMemo(() => {
+    return isHeadline ? (text.headlines || {}) : (text.subheadlines || {});
+  }, [isHeadline, text.headlines, text.subheadlines]);
 
-  // Reset state when modal opens
-  useEffect(() => {
+  const [prevVisible, setPrevVisible] = useState(visible);
+  if (visible !== prevVisible) {
+    setPrevVisible(visible);
     if (visible) {
       setSourceLang(state.currentLanguage || languages[0] || 'en');
       setTranslations({ ...texts });
@@ -42,7 +45,7 @@ export function TranslateModal({ visible, onClose, target, state, dispatch, aiCo
       setStatusType('');
       setTranslating(false);
     }
-  }, [visible]);
+  }
 
   const sourceText = translations[sourceLang] || texts[sourceLang] || '';
   const targetLangs = languages.filter(lang => lang !== sourceLang);
@@ -139,6 +142,12 @@ Translate to these language codes: ${targetLangs.join(', ')}`;
     const key = isHeadline ? 'headlines' : 'subheadlines';
     const merged = { ...texts, ...translations };
     dispatch({ type: SET_TEXT_SETTING, payload: { key, value: merged } });
+
+    // Also update the list of languages with actual translations
+    const langKey = isHeadline ? 'headlineLanguages' : 'subheadlineLanguages';
+    const activeLangs = Object.keys(merged).filter(lang => merged[lang]?.trim());
+    dispatch({ type: SET_TEXT_SETTING, payload: { key: langKey, value: activeLangs } });
+
     onClose();
   }, [isHeadline, texts, translations, dispatch, onClose]);
 
@@ -569,11 +578,13 @@ export function MagicalTitlesModal({ visible, onClose, onConfirm, state, aiConfi
   const providerConfig = llmProviders[provider];
   const providerName = providerConfig?.name || provider || '-';
 
-  useEffect(() => {
+  const [prevVisible, setPrevVisible] = useState(visible);
+  if (visible !== prevVisible) {
+    setPrevVisible(visible);
     if (visible) {
       setSelectedLang(state.currentLanguage || 'en');
     }
-  }, [visible, state.currentLanguage]);
+  }
 
   return (
     <div className={`modal-overlay ${visible ? 'visible' : ''}`}>

--- a/src/components/ScreenshotMaker/utils/canvasRenderer.js
+++ b/src/components/ScreenshotMaker/utils/canvasRenderer.js
@@ -617,7 +617,11 @@ export function renderScreenshotToCanvas(canvas, screenshot, outputWidth, output
   }
 
   // Draw text
-  const txt = screenshot.text;
+  const txt = {
+    ...screenshot.text,
+    currentHeadlineLang: currentLanguage,
+    currentSubheadlineLang: currentLanguage,
+  };
   drawTextToContext(ctx, dims, txt);
 
   // Draw overlay/logo


### PR DESCRIPTION
## Changes
- Fixed the logic so that configured languages in `manage translations` are properly recognized during the batch translation process.
- Ensured that the batch translation executes successfully without triggering the "Add more languages..." warning when languages are set.

## How to Test
1. Set the default language to English.
2. Add target languages in `manage translations`.
3. Execute batch translation for text within `screenshots`.
4. Verify that the translation completes successfully without the warning.

<img width="856" height="867" alt="スクリーンショット 2026-06-09 17 57 51" src="https://github.com/user-attachments/assets/7988a991-17e9-4672-934c-668fd1a5072e" />
